### PR TITLE
Django 1.8 compatibility

### DIFF
--- a/django_nose/runner.py
+++ b/django_nose/runner.py
@@ -20,7 +20,13 @@ from django.core.management.base import BaseCommand
 from django.core.management.color import no_style
 from django.core.management.commands.loaddata import Command
 from django.db import connections, transaction, DEFAULT_DB_ALIAS
-from django.db.backends.creation import BaseDatabaseCreation
+
+try:
+    from django.db.backends.base.creation import BaseDatabaseCreation
+except ImportError:
+    # Django < 1.7
+    from django.db.backends.creation import BaseDatabaseCreation    
+
 from django.utils.importlib import import_module
 
 try:


### PR DESCRIPTION
Django 1.8 has changed the way that the database backends are loaded, https://github.com/django/django/pull/3899
